### PR TITLE
1846 Allow creation of the comment root without a request

### DIFF
--- a/comments/__init__.py
+++ b/comments/__init__.py
@@ -1,4 +1,4 @@
-__version_info__ = (1, 8, 2)
+__version_info__ = (1, 8, 3)
 __version__ = '.'.join(str(i) for i in __version_info__)
 
 default_app_config = 'comments.apps.CommentsConfig'

--- a/comments/utils.py
+++ b/comments/utils.py
@@ -35,35 +35,37 @@ def _get_target_comment(request):
     else:
         raise InvalidCommentException("An error occurred while saving your comment.")
     
+def get_or_create_tree_root(ct_id, obj_id):
+    try:
+        parent_comment = None
+        ct = ContentType.objects.get_for_id(ct_id)
+        obj = ct.get_object_for_this_type(pk=obj_id)
+        try:
+            comment = Comment.objects.get(object_id=obj_id, content_type=ct)
+        except Comment.DoesNotExist:
+            kwargs = {}
+            if hasattr(obj, 'max_comment_depth'):
+                kwargs['max_depth'] = getattr(obj, 'max_comment_depth')()
+            # This 'lock' ensures the creation process is done serially, since there is a built in race condition for mptt's 'tree_id' assignment
+            # The issue for mptt is here: https://github.com/django-mptt/django-mptt/issues/236
+            ct_lock = ContentType.objects.select_for_update().get(app_label='comments', model='comment')
+            comment = Comment.objects.create(content_object=obj, **kwargs)
+
+        # This check adds one query to every ajax call, but I decided to put it here instead of in Comment.save to ensure integrity even between saves.  
+        try:
+            Comment.objects.get(parent=None, tree_id=comment.tree_id)
+        # If there are there are more than one 'root' comments (with no object_id) with the same tree_id...
+        except Comment.MultipleObjectsReturned:
+            # ...then we need to rebuild to ensure integrity
+            Comment.objects.rebuild()
+            
+        return comment, obj
+    except Exception as e:
+        raise InvalidCommentException("Unable to access comment tree: parent object not found.")
+    
 def _get_or_create_tree_root(request):
     if 'ct_id' in request.GET and 'obj_id' in request.GET:
-        try:
-            parent_comment = None
-            ct = ContentType.objects.get_for_id(request.GET.get('ct_id'))
-            obj_id = request.GET.get('obj_id')
-            obj = ct.get_object_for_this_type(pk=obj_id)
-            try:
-                comment = Comment.objects.get(object_id=obj_id, content_type=ct)
-            except Comment.DoesNotExist:
-                kwargs = {}
-                if hasattr(obj, 'max_comment_depth'):
-                    kwargs['max_depth'] = getattr(obj, 'max_comment_depth')()
-                # This 'lock' ensures the creation process is done serially, since there is a built in race condition for mptt's 'tree_id' assignment
-                # The issue for mptt is here: https://github.com/django-mptt/django-mptt/issues/236
-                ct_lock = ContentType.objects.select_for_update().get(app_label='comments', model='comment')
-                comment = Comment.objects.create(content_object=obj, **kwargs)
-            
-            # This check adds one query to every ajax call, but I decided to put it here instead of in Comment.save to ensure integrity even between saves.  
-            try:
-                Comment.objects.get(parent=None, tree_id=comment.tree_id)
-            # If there are there are more than one 'root' comments (with no object_id) with the same tree_id...
-            except Comment.MultipleObjectsReturned:
-                # ...then we need to rebuild to ensure integrity
-                Comment.objects.rebuild()
-                
-            return comment, obj
-        except Exception as e:
-            raise InvalidCommentException("Unable to access comment tree: parent object not found.")
+        return get_or_create_tree_root(request.GET.get('ct_id'), request.GET.get('obj_id'))
     else:
         raise InvalidCommentException("Unable to access comment tree: invalid request parameters.")
     


### PR DESCRIPTION
In order to initialize the root comment for a particular object, there
needs to be a way to call _get_or_create_tree_root without a request.

Without this, you would not be able to create comment objects
programmatically without first having a request ping the load_comments
url with the correct GET params.