### PR TITLE
1437 check for csrfmiddlewaretoken

### DIFF
--- a/comments/static/comments/js/comments.js
+++ b/comments/static/comments/js/comments.js
@@ -17,6 +17,9 @@
             return cookieValue;
         }
         var csrftoken = getCookie('csrftoken');
+        if (csrftoken == null) {
+            csrftoken = BIOSHARE.http.csrfToken();
+        }
 
         // These are mirrored in the 'initialize_comments' template tag. Any change here should be reflected there.
         var settings = $.extend({

--- a/comments/static/comments/js/comments.js
+++ b/comments/static/comments/js/comments.js
@@ -18,7 +18,7 @@
         }
         var csrftoken = getCookie('csrftoken');
         if (csrftoken == null) {
-            csrftoken = BIOSHARE.http.csrfToken();
+            csrftoken = $("[name=csrfmiddlewaretoken]").val();
         }
 
         // These are mirrored in the 'initialize_comments' template tag. Any change here should be reflected there.


### PR DESCRIPTION
Update csrftken access to coorespond with bioshare issue 1437, which removed getCookie() from bioshare.http.js and added csrfToken()